### PR TITLE
fix: refactor message component and fix reponsive

### DIFF
--- a/src/components/Message.tsx
+++ b/src/components/Message.tsx
@@ -10,16 +10,19 @@ interface MessageProps {
 
 export const Message = ({ role, content, isLoading }: MessageProps) => {
   return (
-    <div className="w-full bg-white/80 rounded-lg flex gap-4 p-5">
-      <Image
-        alt={`${role} Profile Pic`}
-        className="size-[20px] md:size-[40px]"
-        width={40}
-        height={40}
-        src={role === "user" ? "/User.png" : "/Patricio.png"}
-      />
-      <div className="w-full">
+    <div className="w-full bg-white/80 rounded-lg flex flex-col gap-4 p-5">
+      <div className="flex items-center gap-2">
+        <div>
+          <Image
+            alt={`${role} Profile Pic`}
+            width={40}
+            height={40}
+            src={role === "user" ? "/User.png" : "/Patricio.png"}
+          />
+        </div>
         <strong>{role === "user" ? "Tú" : "Patricio"}</strong>
+      </div>
+      <div className="w-full space-y-4">
         {isLoading && role !== "user" && !content.length ? (
           <span>...</span>
         ) : (


### PR DESCRIPTION
Este PR soluciona el error de desbordamiento del componente de mensajes cuando se le pedía a Patricio ejemplos de código (#1). Además se refactorizó el componente para arreglar el tamaño de los avatares.

Antes:

![before](https://github.com/user-attachments/assets/bee4d614-9300-44b8-9981-890f8905acbf)

Después:

![after](https://github.com/user-attachments/assets/0763fe35-36d6-4f50-8217-25b7e4a19f73)
